### PR TITLE
Created support for substitution

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,18 @@ Output:
     test1
     test2
 
+Each line may also be prefixed with a custom string, and have substitutions applied to it.
+
+Example:
+
+    echo -e "a\nb\nc" | coshell -p "echo ?{3#10} : " -e "?"
+
+Output:
+
+    010 : a
+    011 : b
+    012 : c
+
 ## deinterlace option
 
 Order is not deterministic by default, but with option ``--deinterlace`` or ``-d`` all output will be buffered and afterwards
@@ -63,6 +75,27 @@ all processes to immediately exit (including coshell) with the exit code of such
 The `--master=n` or `-m=n` option takes a positive integer number as the index of specified command lines to identify
 which process "leads" the pack: when the process exits all neighbour processes will be terminated as well and its exit code
 will be adopted as coshell exit code.
+
+## prefix option
+
+With `-prefix "some_cmd"` or `-p "some_cmd"`, each line of input will be prepended with some_cmd. This can be used to 
+check the commands before they run, for instance, with -p "echo ".
+
+## escape option
+
+The `-escape` or `-e` option allows substitution of certain patterns in the prefix string for each line. If the option
+is given with a value like `-e "#"` then the substitution escape character will be set to "#". "?" by default. 
+Any string may be used.
+
+### escape patterns
+
+Assuming the default escape string "?" and `-e` is provided, using `-p "some_prefix "` will yield the following, given:
+
+    `" ?{} "`        ?{} will be substituted with the line that is given. If no ?{} is given, it is appended to the prefix.
+    `" ?{#} "`       ?{#} will be substituted with the number of the line, starting with 0.
+    `" ?{2#} "`      ?{2#} will be substituted with the number of the line, padded but not limited, to 2 characters. eg. 08
+    `" ?{#1} "`      ?{#1} will be substituted with the number of the line, starting with 1.
+    `" ?{5#5} "`     ?{5#5} will be substituted with the number of the line, starting with 5, padded to 5 or more characters.
 
 ## Examples
 

--- a/coshell.go
+++ b/coshell.go
@@ -37,7 +37,9 @@ func fatal(err error) {
 }
 
 func main() {
-	var deinterlace, halt, nextMightBeMasterId bool
+	var deinterlace, halt, nextMightBeMasterId, expectCommandPrefix, expectEscapeChar bool
+	prefix := ""
+	escape := ""
 	masterId := -1
 	if len(os.Args) > 1 {
 		for i := 1; i < len(os.Args); i++ {
@@ -95,14 +97,37 @@ func main() {
 				continue
 			}
 
+			if expectCommandPrefix {
+				if len(os.Args[i]) < 1 || rune(os.Args[i][0]) == '-' {
+					continue
+				}
+				prefix = os.Args[i]
+				expectCommandPrefix = false
+				continue
+			}
+
+			if expectEscapeChar {
+				if len(os.Args[i]) < 1 || rune(os.Args[i][0]) == '-' {
+					continue
+				}
+				escape = os.Args[i]
+				expectEscapeChar = false
+				continue
+			}
+
 			switch os.Args[i] {
 			case "--help", "-h":
 				fmt.Printf("coshell v0.1.4 by gdm85 - Licensed under GNU GPLv2\n")
-				fmt.Printf("Usage:\n\tcoshell [--help|-h] [--deinterlace|-d] [--halt-all|-a] < list-of-commands\n")
+				fmt.Printf("Usage:\n\tcoshell [--help|-h] [--deinterlace|-d] [--halt-all|-a] [--cmd|-c \"prefix-to-each-command\"] [--parse|-p[=\"$\"]] < list-of-commands\n")
 				fmt.Printf("\t\t--deinterlace | -d\t\tShow individual output of processes in blocks, second order of termination\n\n")
-				fmt.Printf("\t\t--halt-all | -a\t\tTerminate neighbour processes as soon as any has failed, using its exit code\n\n")
+				fmt.Printf("\t\t--halt-all | -a\t\t\tTerminate neighbour processes as soon as any has failed, using its exit code\n\n")
 				fmt.Printf("\t\t--master=0 | -m=0\t\tTerminate neighbour processes as soon as command from specified input line exits and use its exit code; if no id is specified, 0 is assumed\n\n")
-				fmt.Printf("Each line read from standard input will be run as a command via `sh -c`\n")
+				fmt.Printf("\t\t--prefix \"echo \" | -p \"echo \"\tPrefix each line of input with the given string. Use -c=\"echo \", for instance, to check each line rather than execute.\n\n")
+				fmt.Printf("\t\t--escape \"!\" | -e \"!\"\t\tSubstitute parts of the prefix string according to the following rules, optionally using an escape character (! by default).\n")
+				fmt.Printf("\t\t\t!{}\t\t\t\tSubstitute the input line. This will remove it as the suffix unless explicitly used at the end of the prefix. May be used multiple times in the prefix.\n")
+				fmt.Printf("\t\t\t!{#}\t\t\t\tSubstitute the input line number, starting with 0.\n")
+				fmt.Printf("\t\t\t!{p#n}\t\t\t\tSubstitute the input line number, where p and n are both optional integers. P indicates the padded length of the substituded line number. N indicates starting value.\n")
+				fmt.Printf("\nBy default, each line read from standard input will be run as a command via `sh -c`\n")
 				os.Exit(0)
 			case "--halt-all", "-a":
 				halt = true
@@ -110,11 +135,22 @@ func main() {
 			case "--deinterlace", "-d":
 				deinterlace = true
 				continue
+			case "--prefix", "-p":
+				expectCommandPrefix = true
+				continue
+			case "--escape", "-e":
+				expectEscapeChar = true
+				continue
 			default:
 				fmt.Fprintf(os.Stderr, "Invalid parameter specified: %s\n", os.Args[i])
 			}
 			os.Exit(1)
 		}
+	}
+
+	// if we never get that escape string we expected, use default.
+	if expectEscapeChar {
+		escape = "!"
 	}
 
 	// collect all commands to run from stdin
@@ -132,6 +168,12 @@ func main() {
 			// crash in case of other errors
 			fatal(err)
 			return
+		}
+
+		// ensure that parsing is enabled and we have something to parse
+		if escape != "" && prefix != "" {
+			lineNumber := len(commandLines)
+			line = parseLine(escape, prefix, line, lineNumber)
 		}
 
 		commandLines = append(commandLines, line)
@@ -167,4 +209,66 @@ func main() {
 	}
 
 	os.Exit(exitCode)
+}
+
+func parseLine(escape, prefix, line string, lineNumber int) string {
+	// double verifying that prefix and escape are longer than 0
+	if len(prefix) < 1 || len(escape) < 1 {
+		return line
+	}
+
+	// if we don't have any line substitution (!{}) in the prefix, append one
+	if !strings.Contains(prefix, escape+"{}") {
+		prefix = prefix + escape + "{}"
+	}
+
+	// find parseable substitutions
+	parts := strings.Split(prefix, escape+"{")
+
+	for i := len(parts) - 1; i > 0; i-- {
+
+		// check if this is just !{}, if so replace and move on
+		// would be nice to just .Replace earlier, but may lead to recursion
+		if parts[i][0] == '}' {
+			remain := strings.TrimPrefix(parts[i], "}")
+			parts[i] = line + remain
+			continue
+		}
+
+		segments := strings.SplitN(parts[i], "}", 2)
+		if len(segments) != 2 {
+			fatal(errors.New("Malformed prefx string! Use without -e or check that substitutions match."))
+		}
+
+		subCmd := strings.TrimFunc(segments[0], func(r rune) bool {
+			// return true to remove each digit character
+			// NOTE: only trimming from sides. 123#3#321 => #3#
+			return strings.IndexRune("0123456789", r) >= 0
+		})
+
+		// the following will give ["", ""] if no args
+		args := strings.Split(segments[0], subCmd)
+
+		if args[0] == "" {
+			args[0] = "1"
+		}
+		if args[1] == "" {
+			args[1] = "0"
+		}
+
+		// we can now check which substitution command was used
+		// note we can also define ranges in the prefix using segments[1] to format uppercase, for example. Perhaps allow all but !{} in input lines?
+		switch subCmd {
+		case "#":
+			padding := args[0]
+			offset, err := strconv.Atoi(args[1])
+			if err != nil {
+				fatal(err) //errors.New("Malformed substitution! Use without -e or check that format is correct."))
+			}
+			parts[i] = fmt.Sprintf("%0"+padding+"d%s", offset+lineNumber, segments[1])
+			continue
+		}
+	}
+
+	return strings.Join(parts, "")
 }

--- a/coshell.go
+++ b/coshell.go
@@ -50,7 +50,7 @@ func coshell() int {
 				nextMightBeMasterId = false
 				if len(os.Args[i]) == 0 {
 					fmt.Fprintf(os.Stderr, "Empty master command index specified\n")
-//					os.Exit(1)
+					//					os.Exit(1)
 					return 1
 				}
 
@@ -65,7 +65,7 @@ func coshell() int {
 				i, err := strconv.Atoi(os.Args[i])
 				if err != nil || i < 0 {
 					fmt.Fprintf(os.Stderr, "Invalid master command index specified: %s\n", os.Args[i])
-//					os.Exit(1)
+					//					os.Exit(1)
 					return 1
 				}
 				masterId = i
@@ -93,7 +93,7 @@ func coshell() int {
 				i, err := strconv.Atoi(remainder)
 				if err != nil || i < 0 {
 					fmt.Fprintf(os.Stderr, "Invalid master command index specified: %s\n", remainder)
-//					os.Exit(1)
+					//					os.Exit(1)
 					return 1
 				}
 				masterId = i
@@ -131,7 +131,7 @@ func coshell() int {
 				fmt.Printf("\t\t\t!{#}\t\t\t\tSubstitute the input line number, starting with 0.\n")
 				fmt.Printf("\t\t\t!{p#n}\t\t\t\tSubstitute the input line number, where p and n are both optional integers. P indicates the padded length of the substituded line number. N indicates starting value.\n")
 				fmt.Printf("\nBy default, each line read from standard input will be run as a command via `sh -c`\n")
-//				os.Exit(0)
+				//				os.Exit(0)
 				return 0
 			case "--halt-all", "-a":
 				halt = true
@@ -148,7 +148,7 @@ func coshell() int {
 			default:
 				fmt.Fprintf(os.Stderr, "Invalid parameter specified: %s\n", os.Args[i])
 			}
-//			os.Exit(1)
+			//			os.Exit(1)
 			return 1
 		}
 	}
@@ -164,7 +164,7 @@ func coshell() int {
 	reader := bufio.NewReader(os.Stdin)
 	for {
 		line, err := reader.ReadString('\n')
-		line = strings.TrimSuffix(line,"\n")
+		line = strings.TrimSuffix(line, "\n")
 
 		if err != nil {
 			if err == io.EOF {
@@ -181,7 +181,7 @@ func coshell() int {
 			lineNumber := len(commandLines)
 			line = parseLine(escape, prefix, line, lineNumber)
 		} else { // if there is no parsing but still have a prefix
-			line = prefix+line
+			line = prefix + line
 		}
 
 		commandLines = append(commandLines, line)
@@ -216,7 +216,7 @@ func coshell() int {
 		return -1
 	}
 
-//	os.Exit(exitCode)
+	//	os.Exit(exitCode)
 	return exitCode
 }
 

--- a/coshell_test.go
+++ b/coshell_test.go
@@ -8,28 +8,28 @@ import (
 
 func TestMain(t *testing.T) {
 
-	testCompare(t,"Test basic operation",
+	testCompare(t, "Test basic operation",
 		testHelper([]string{"coshell"}, "echo a\necho b\necho c\n"),
 		"a\nb\nc\n",
 	)
 
-	testCompare(t,"Test the prefix string",
+	testCompare(t, "Test the prefix string",
 		testHelper([]string{"coshell", "-p", "echo "}, "a\nb\nc\n"),
 		"a\nb\nc\n",
 	)
 
-	testCompare(t,"Test the default escape string",
+	testCompare(t, "Test the default escape string",
 		testHelper([]string{"coshell", "-p", "echo ?{} ?{3#3}", "-e"}, "a\nb\nc\n"),
 		"a 003\nb 004\nc 005\n",
 	)
 
 }
 
-func testCompare(t *testing.T, description, result, expect string){
+func testCompare(t *testing.T, description, result, expect string) {
 	if result != expect {
-		t.Fatalf("%s:\n\t%q got, expected:\n\t%q\n",description,result,expect)
+		t.Fatalf("%s:\n\t%q got, expected:\n\t%q\n", description, result, expect)
 	} else {
-		t.Logf("[PASSED] %s",description)
+		t.Logf("[PASSED] %s", description)
 	}
 }
 
@@ -52,19 +52,19 @@ func testHelper(args []string, input string) string {
 		//var buf bytes.Buffer
 		//io.Copy(&buf, ro)
 		buf, err := ioutil.ReadAll(ro)
-		if err!=nil {
+		if err != nil {
 			panic(err)
 		}
 		outC <- string(buf)
 	}()
-	go func (){
+	go func() {
 		coshell()
 		wo.Close()
 		done <- 1
 	}()
 	wi.Write([]byte(input))
 	wi.Close()
-	<- done
+	<-done
 	out := <-outC
 	return out
 }

--- a/coshell_test.go
+++ b/coshell_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestMain(t *testing.T) {
+
+	testCompare(t,"Test basic operation",
+		testHelper([]string{"coshell"}, "echo a\necho b\necho c\n"),
+		"a\nb\nc\n",
+	)
+
+	testCompare(t,"Test the prefix string",
+		testHelper([]string{"coshell", "-p", "echo "}, "a\nb\nc\n"),
+		"a\nb\nc\n",
+	)
+
+	testCompare(t,"Test the default escape string",
+		testHelper([]string{"coshell", "-p", "echo ?{} ?{3#3}", "-e"}, "a\nb\nc\n"),
+		"a 003\nb 004\nc 005\n",
+	)
+
+}
+
+func testCompare(t *testing.T, description, result, expect string){
+	if result != expect {
+		t.Fatalf("%s:\n\t%q got, expected:\n\t%q\n",description,result,expect)
+	} else {
+		t.Logf("[PASSED] %s",description)
+	}
+}
+
+func testHelper(args []string, input string) string {
+	os.Args = args
+	ro, wo, _ := os.Pipe()
+	ri, wi, _ := os.Pipe()
+	oldStdout := os.Stdout
+	oldStdin := os.Stdin // connected to /dev/null in tests, anyway
+	os.Stdout = wo
+	os.Stdin = ri
+	defer func() {
+		os.Stdout = oldStdout
+		os.Stdin = oldStdin
+	}()
+	outC := make(chan string)
+	done := make(chan int)
+	// copy the output in a separate goroutine so printing can't block indefinitely
+	go func() {
+		//var buf bytes.Buffer
+		//io.Copy(&buf, ro)
+		buf, err := ioutil.ReadAll(ro)
+		if err!=nil {
+			panic(err)
+		}
+		outC <- string(buf)
+	}()
+	go func (){
+		coshell()
+		wo.Close()
+		done <- 1
+	}()
+	wi.Write([]byte(input))
+	wi.Close()
+	<- done
+	out := <-outC
+	return out
+}


### PR DESCRIPTION
Hey, if you're interested I've added basic support for doing this:

```
echo -e "a\nb\nc" | go run coshell.go -p "echo ?{#} : ?{}" -e "?"
0 : a
1 : b
2 : c
````

Y'know, cause parallel can do that, though noisily.